### PR TITLE
update washers resolvers for sls

### DIFF
--- a/__tests__/washers.ts
+++ b/__tests__/washers.ts
@@ -1,4 +1,5 @@
 import * as env from "dotenv";
+import gql from "graphql-tag";
 import { BatchPayload, prisma, Washer } from "../src/generated/prisma-client";
 import { GraphQLResponse } from "apollo-server-types";
 import { createTestClient } from "apollo-server-testing";
@@ -34,12 +35,14 @@ describe("the graphql washers api", () => {
     await createTestWasher(testWasher);
 
     // query and check response
-    const query = `{
-      washers {
-        id
-        in_use
+    const query = gql`
+      query {
+        washers {
+          id
+          in_use
+        }
       }
-    }`;
+    `;
     const response: GraphQLResponse = await client.query({ query });
     expect(response.data).toEqual({
       washers: [testWasher],
@@ -58,19 +61,20 @@ describe("the graphql washers api", () => {
     await createTestWasher(testWasher);
 
     // update and check response
-    const mutation = `{
-      updateWasher(id: ID!, in_use: Boolean!) {
-        id
-        in_use
+    const mutation = gql`
+      mutation($id: ID!, $in_use: Boolean!) {
+        updateWasher(id: $id, in_use: $in_use) {
+          id
+          in_use
+        }
       }
-    }`;
+    `;
     const variables = { id: "1", in_use: false };
     const response: GraphQLResponse = await client.mutate({
       mutation,
       variables,
     });
-    console.log(response);
-    expect(response.data).toEqual({ washer: { id: "1", in_use: false } });
+    expect(response.data).toEqual({ updateWasher: { id: "1", in_use: false } });
 
     await deleteTestWashers();
   });

--- a/__tests__/washers.ts
+++ b/__tests__/washers.ts
@@ -1,21 +1,22 @@
 import * as env from "dotenv";
+import { BatchPayload, prisma, Washer } from "../src/generated/prisma-client";
+import { GraphQLResponse } from "apollo-server-types";
+import { createTestClient } from "apollo-server-testing";
+import { createTestServerWithToken } from "./utils/server";
+
 env.config();
 
-import { BatchPayload, prisma, Washer } from "../src/generated/prisma-client";
-import { createTestClient } from "apollo-server-testing";
-import testServer from "../src/server";
-
-const createTestWasher = (washer): Promise<Washer> =>
-  prisma.createWasher(washer);
+const createTestWasher = (washer: {
+  id: string;
+  in_use: boolean;
+}): Promise<Washer> => prisma.createWasher(washer);
 
 const deleteTestWashers = (): Promise<BatchPayload> =>
   prisma.deleteManyWashers({});
 
 const testWasher = {
   id: "1",
-  status: "IDLE",
-  time_elapsed: "0",
-  time_remaining: "0",
+  in_use: true,
 };
 
 beforeAll(async () => {
@@ -24,21 +25,53 @@ beforeAll(async () => {
 
 describe("the graphql washers api", () => {
   test("returns the status of the washing machines", async () => {
+    // create a test server with token
+    const testServer = createTestServerWithToken("some_token");
+    // create a test client connected to the test server
     const client = createTestClient(testServer);
+
     await deleteTestWashers();
     await createTestWasher(testWasher);
-    const washerQuery = `{
-            washer(id: ${testWasher.id}) {
-                id
-                status
-                time_elapsed
-                time_remaining
-            }
-        }`;
-    const queryResponse = await client.query({ query: washerQuery });
-    expect(queryResponse.data).toEqual({
-      washer: testWasher,
+
+    // query and check response
+    const query = `{
+      washers {
+        id
+        in_use
+      }
+    }`;
+    const response: GraphQLResponse = await client.query({ query });
+    expect(response.data).toEqual({
+      washers: [testWasher],
     });
+
+    await deleteTestWashers();
+  });
+
+  test("updates the status of a machine", async () => {
+    // create a test server with token
+    const testServer = createTestServerWithToken("some_token");
+    // create a test client connected to the test server
+    const client = createTestClient(testServer);
+
+    await deleteTestWashers();
+    await createTestWasher(testWasher);
+
+    // update and check response
+    const mutation = `{
+      updateWasher(id: ID!, in_use: Boolean!) {
+        id
+        in_use
+      }
+    }`;
+    const variables = { id: "1", in_use: false };
+    const response: GraphQLResponse = await client.mutate({
+      mutation,
+      variables,
+    });
+    console.log(response);
+    expect(response.data).toEqual({ washer: { id: "1", in_use: false } });
+
     await deleteTestWashers();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -930,7 +930,8 @@
     "acorn": {
       "version": "5.7.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -4092,9 +4093,9 @@
       }
     },
     "graphql-tag": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
-      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg=="
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.3.tgz",
+      "integrity": "sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA=="
     },
     "graphql-tools": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-jest": "^23.6.0",
     "eslint-plugin-prettier": "^3.1.2",
+    "graphql-tag": "^2.10.3",
     "husky": "^4.0.10",
     "jest": "^24.9.0",
     "lint-staged": "^10.0.0",

--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -20,9 +20,8 @@ type UserSessions {
 
 type Washer {
     id: ID! @id
-    status: String!
-    time_elapsed: String!
-    time_remaining: String!
+    in_use: Boolean!
+    updatedAt: DateTime! @updatedAt
 }
 
 type Room {

--- a/src/mutations/washers.ts
+++ b/src/mutations/washers.ts
@@ -1,0 +1,14 @@
+import { Washer } from "../generated/prisma-client";
+
+const updateWasher = async (parent, { id, in_use }, ctx): Promise<Washer> => {
+  return ctx.prisma.updateWasher({
+    data: {
+      in_use,
+    },
+    where: {
+      id,
+    },
+  });
+};
+
+export { updateWasher };

--- a/src/query/washer.ts
+++ b/src/query/washer.ts
@@ -1,8 +1,0 @@
-import { FragmentableArray, Washer } from "../generated/prisma-client";
-
-const washer = (parent, { id }, ctx): FragmentableArray<Washer> =>
-  ctx.prisma.washer({
-    id,
-  });
-
-export default washer;

--- a/src/query/washers.ts
+++ b/src/query/washers.ts
@@ -1,0 +1,4 @@
+import { FragmentableArray, Washer } from "../generated/prisma-client";
+
+export const washers = (parent, { data }, ctx): FragmentableArray<Washer> =>
+  ctx.prisma.washers({ where: data, orderBy: "id_ASC" });

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,6 +1,6 @@
 import { login, register } from "./mutations/user";
 import { user, me } from "./query/user";
-import washer from "./query/washer";
+import { washers } from "./query/washers";
 import { bookings, rooms } from "./query/bookings";
 import { events } from "./query/events";
 import {
@@ -16,7 +16,7 @@ const resolvers: IResolvers = {
   Query: {
     user,
     me,
-    washer,
+    washers,
     bookings,
     rooms,
     events,

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -3,6 +3,7 @@ import { user, me } from "./query/user";
 import { washers } from "./query/washers";
 import { bookings, rooms } from "./query/bookings";
 import { events } from "./query/events";
+import { updateWasher } from "./mutations/washers";
 import {
   createBooking,
   updateBooking,
@@ -24,6 +25,7 @@ const resolvers: IResolvers = {
   Mutation: {
     login,
     register,
+    updateWasher,
     createBooking,
     updateBooking,
     deleteBooking,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,5 +1,6 @@
 # import User from "./generated/prisma.graphql"
 # import Washer from "./generated/prisma.graphql"
+# import WasherWhereInput from "./generated/prisma.graphql"
 # import Booking from "./generated/prisma.graphql"
 # import Room from "./generated/prisma.graphql"
 # import BookingWhereInput from "./generated/prisma.graphql"
@@ -16,7 +17,7 @@ input UserRegisterInput {
 type Query {
     user(username: String!): User
     me : User
-    washer(id: ID!): Washer
+    washers (data: WasherWhereInput): [Washer]
     bookings (data: BookingWhereInput): [Booking]
     rooms (data: RoomWhereInput) : [Room]
     events (data: EventWhereInput) : [Event]

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -28,6 +28,7 @@ type Mutation {
     register(
         user : UserRegisterInput!
     ) : User
+    updateWasher(id: ID!, in_use: Boolean!): Washer
     createBooking(room_number: String!, start: String!, end: String!, remark: String) : Booking
     updateBooking(id: ID!, room_number: String!, start: String!, end: String!, remark: String): Booking
     deleteBooking(id: ID!): Booking


### PR DESCRIPTION
new data model:
```
type Washer {
  id
  in_use: Boolean! // to indicate if washer is being used
  updatedAt: // to show last updated at
}
```

api:
```
query washers
update washer (id)
```

I was thinking that there should be exactly 4 of these `Washer`s, and the hardware just sends requests to update the data table

as far as this goes, no security has been set up yet, literally anyone can just hit the api and mutate the washer statuses, will have to incorporate some form of verification between sls and phoenix
querying data is completely public, and should stay that way

also fixes `__tests__` for `bookings`, I realised there was an issue with testing for invalid booking data where the graphql mutation is incorrectly written, resulting in a consistent failed response, unrelated to the actual test designed